### PR TITLE
typo fix which prevented handler from working properly

### DIFF
--- a/lib/chef/chef_handler_librato.rb
+++ b/lib/chef/chef_handler_librato.rb
@@ -24,7 +24,7 @@ require "chef"
 require "chef/handler"
 
 class LibratoReporting < Chef::Handler
-  attr_writer :metrics_type, :source, :email, :api_key
+  attr_writer :metric_type, :source, :email, :api_key
 
   def initialize(options = {})
     @metric_type = options[:metric_type] || "counter"


### PR DESCRIPTION
You've mistyped the class attribute name and this have lead to being unable to use `gauge` as a metric type.
