### PR TITLE
Prefixing, multiple metric types, Chef 12, Librato annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ language: ruby
 env:
   - CI=true
 rvm:
-  - 1.9.2
-  - 1.9.3
+  - 2.0.0
 gemfile:
   - Gemfile
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: ruby
 env:
   - CI=true
 rvm:
-  - 2.0.0
+  - 2.1.1
 gemfile:
   - Gemfile
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source "http://rubygems.org/"
 
 gem 'rake'
+gem 'chef', '>=12.0'
+
 gemspec

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ chef-handler-librato
 
 Chef Handler to send metrics to Librato metrics!
 
+This fork integrates changes from [Pete Cheslock](https://github.com/petecheslock) and [Jesse Nelson](https://github.com/spheromak).
+
 ====Description====
 
 This is a simple Chef report handler that reports status of a Chef run through librato.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@ chef-handler-librato
 
 ====================
 #### Build Status
-[![Build Status](https://travis-ci.org/mjuarez/chef-handler-librato.svg)](https://travis-ci.org/mjuarez/chef-handler-librato)
+[![Build Status](https://travis-ci.org/bscott/chef-handler-librato.svg)](https://travis-ci.org/bscott/chef-handler-librato)
 
 ====================
 
 Chef Handler to send metrics to Librato metrics!
 
-This fork from [Brian Scott](https://github.com/bscott/chef-handler-librato) integrates changes from [Pete Cheslock](https://github.com/petecheslock) and [Jesse Nelson](https://github.com/spheromak).
-
-====Description====
+##Description
 
 This is a simple Chef report handler that reports status of a Chef run through librato.
 
@@ -36,10 +34,6 @@ Then add to the configuration (/etc/chef/solo.rb for chef-solo or /etc/chef/clie
 	librato_handler = LibratoReporting.new
 
 #### Arguments:
-
-#### metric_type is a string that sets the Metrics type in Librato, defaults to counter
-
-	librato_handler.metric_type = "gauge"
 
 #### Email and Api_key arguments
 
@@ -86,6 +80,12 @@ or
 
 Patches welcome, just send me a pull request!
 
-Author: Brian Scott (brainscott@gmail.com)
+Author:
 
+* Brian Scott (brainscott@gmail.com)
 
+Contributions:
+
+* [Pete Cheslock](https://github.com/petecheslock)
+* [Jesse Nelson](https://github.com/spheromak)
+* [Mike Juarez](https://github.com/mjuarez)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@ chef-handler-librato
 
 ====================
 #### Build Status
-[![Build Status](https://travis-ci.org/bscott/chef-handler-librato.png?branch=master)](https://travis-ci.org/bscott/chef-handler-librato)
+[![Build Status](https://travis-ci.org/mjuarez/chef-handler-librato.svg)](https://travis-ci.org/mjuarez/chef-handler-librato)
 
 ====================
 
 Chef Handler to send metrics to Librato metrics!
 
-This fork integrates changes from [Pete Cheslock](https://github.com/petecheslock) and [Jesse Nelson](https://github.com/spheromak).
+This fork from [Brian Scott](https://github.com/bscott/chef-handler-librato) integrates changes from [Pete Cheslock](https://github.com/petecheslock) and [Jesse Nelson](https://github.com/spheromak).
 
 ====Description====
 

--- a/chef-handler-librato.gemspec
+++ b/chef-handler-librato.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "chef-handler-librato"
-  s.version     = "1.1.6"
+  s.version     = "1.2.0"
   s.authors     = ["Brian Scott"]
   s.email       = ["brainscott@gmail.com"]
   s.homepage    = ""
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_development_dependency "librato-metrics"
   s.add_development_dependency "rspec"
   s.add_runtime_dependency "chef", '>= 0'
   s.add_runtime_dependency "aggregate", '>= 0'

--- a/lib/chef/chef_handler_librato.rb
+++ b/lib/chef/chef_handler_librato.rb
@@ -43,11 +43,11 @@ class LibratoReporting < Chef::Handler
     Librato::Metrics.authenticate "#{@email}", "#{@api_key}"
 
     metrics = {}
-    metrics[:guage] = {}
+    metrics[:gauge] = {}
     metrics[:counter] = {}
-    metrics[:guage][:updated_resources] = run_status.updated_resources.length
-    metrics[:guage][:all_resources] = run_status.all_resources.length
-    metrics[:guage][:elapsed_time] = run_status.elapsed_time.to_i
+    metrics[:gauge][:updated_resources] = run_status.updated_resources.length
+    metrics[:gauge][:all_resources] = run_status.all_resources.length
+    metrics[:gauge][:elapsed_time] = run_status.elapsed_time.to_i
 
     if run_status.success?
       metrics[:counter][:success] = 1
@@ -57,7 +57,7 @@ class LibratoReporting < Chef::Handler
       metrics[:counter][:fail] = 1
     end
 
-    metrics.each do |guage, data|
+    metrics.each do |gauge, data|
       data.each do |metric, value|
         Chef::Log.debug("#{metric} #{value} #{Time.now}")
         begin

--- a/lib/chef/chef_handler_librato.rb
+++ b/lib/chef/chef_handler_librato.rb
@@ -58,14 +58,15 @@ class LibratoReporting < Chef::Handler
     end
 
     metrics.each do |gauge, data|
-      data.each do |metric, value|
-        Chef::Log.debug("#{metric} #{value} #{Time.now}")
-        begin
-          Librato::Metrics.submit :"#{metric}" => { type: :"#{guage}", value: "#{value}", source: "#{@source}" }
-          rescue => e
-            puts "#{e}"
+    metrics.each do |metric, value|
+      Chef::Log.debug("#{metric} #{value} #{Time.now}")
+      begin
+      Librato::Metrics.submit :"chef.#{metric}" => {:type => :"#{@metric_type}", :value => "#{value}", :source => "#{@source}" }
+      rescue Exception => e
+        puts "#{e}"
         end
       end
     end
   end
 end
+

--- a/lib/chef/chef_handler_librato.rb
+++ b/lib/chef/chef_handler_librato.rb
@@ -43,6 +43,8 @@ class LibratoReporting < Chef::Handler
     Librato::Metrics.authenticate "#{@email}", "#{@api_key}"
 
     metrics = {}
+    metrics[:guage] = {}
+    metrics[:counter] = {}
     metrics[:guage][:updated_resources] = run_status.updated_resources.length
     metrics[:guage][:all_resources] = run_status.all_resources.length
     metrics[:guage][:elapsed_time] = run_status.elapsed_time.to_i

--- a/lib/chef/chef_handler_librato.rb
+++ b/lib/chef/chef_handler_librato.rb
@@ -17,6 +17,7 @@
 #
 
 require 'rubygems'
+require 'date'
 Gem.clear_paths
 require 'librato/metrics'
 require 'chef'
@@ -49,6 +50,10 @@ class LibratoReporting < Chef::Handler
     metrics[:gauge][:all_resources] = run_status.all_resources.length
     metrics[:gauge][:elapsed_time] = run_status.elapsed_time.to_i
 
+    annotations = {}
+    annotations[:start_time] = DateTime.parse(run_status.start_time).strftime('%s')
+    annotations[:end_time] = DateTime.parse(run_status.end_time).strftime('%s')
+
     if run_status.success?
       metrics[:counter][:success] = 1
       metrics[:counter][:fail] = 0
@@ -67,6 +72,10 @@ class LibratoReporting < Chef::Handler
         end
       end
     end
+
+    Chef::Log.debug("Librato annotation chef.converge at #{annotations[:start_time]} - #{annotations[:end_time]}")
+    Librato::Metrics.annotate :"chef.converge", "Chef converge on #{@source}", :source => @source, :start_time => annotations[:start_time], :end_time => annotations[:end_time]
+
   end
 end
 

--- a/lib/chef/chef_handler_librato.rb
+++ b/lib/chef/chef_handler_librato.rb
@@ -23,7 +23,7 @@ require 'chef'
 require 'chef/handler'
 
 class LibratoReporting < Chef::Handler
-  attr_accessor :metric_type, :source, :email, :api_key
+  attr_accessor :source, :email, :api_key
 
   def initialize(options = {})
     @source = options[:source] || "#{Chef::Config[:node_name]}"
@@ -57,13 +57,13 @@ class LibratoReporting < Chef::Handler
       metrics[:counter][:fail] = 1
     end
 
-    metrics.each do |gauge, data|
-    metrics.each do |metric, value|
-      Chef::Log.debug("#{metric} #{value} #{Time.now}")
-      begin
-      Librato::Metrics.submit :"chef.#{metric}" => {:type => :"#{@metric_type}", :value => "#{value}", :source => "#{@source}" }
-      rescue Exception => e
-        puts "#{e}"
+    metrics.each do |metric_type, data|
+      data.each do |metric, value|
+        Chef::Log.debug("#{metric} #{value} #{Time.now}")
+        begin
+        Librato::Metrics.submit :"chef.#{metric}" => {:type => :"#{metric_type}", :value => "#{value}", :source => "#{@source}" }
+        rescue Exception => e
+          puts "#{e}"
         end
       end
     end

--- a/spec/librato_spec.rb
+++ b/spec/librato_spec.rb
@@ -1,24 +1,26 @@
 require 'spec_helper'
 Dir[File.join(File.expand_path("../../lib/chef/*.rb", __FILE__))].each { |f| require f }
 
+testoptions = {
+  :source => "test",
+  :email => "test@test.com",
+  :api_key => "asdfg"
+}
+
+librato = LibratoReporting.new testoptions
+
 describe LibratoReporting do
 
-  it "Metric should return counter" do
-    librato = LibratoReporting.new
-    librato.metric_type.should == 'counter'
-    librato.email.should == 'test@test.com'
-    librato.api_key.should == 'asdfg'
+  it "Source should return a valid name" do
+    expect(librato.source).to eq('test')
   end
 
   it "Email should return a valid email address" do
-    librato = LibratoReporting.new
-    librato.email.should == 'test@test.com'
-    librato.api_key.should == 'asdfg'
+    expect(librato.email).to eq('test@test.com')
   end
 
   it "API Key should return something" do
-    librato = LibratoReporting.new
-    librato.api_key.should == 'asdfg'
+    expect(librato.api_key).to eq('asdfg')
   end
 	
 end


### PR DESCRIPTION
* Integrates changes from @spheromak and @petecheslock's forks
  * Adds `chef.` prefix
  * Creates counter and gauge metric types
* Add Librato annotations for Chef converge start and stop times
* Updates to handle for Chef 12 and Ruby 2.1.1